### PR TITLE
fix errors when build on other platforms

### DIFF
--- a/DemoApp/Assets/Plugins/Crittercism_Android_Scripts/CrittercismAndroid.cs
+++ b/DemoApp/Assets/Plugins/Crittercism_Android_Scripts/CrittercismAndroid.cs
@@ -1,3 +1,6 @@
+#if UNITY_ANDROID && !UNITY_EDITOR
+#define CRITTERCISM_ENABLED
+#endif
 
 using UnityEngine;
 using System.Collections;
@@ -13,49 +16,52 @@ public static class CrittercismAndroid
 		static bool _ShowDebugOnOnRelease = true;
 		private static bool isInitialized = false;
 		private static readonly string CRITTERCISM_CLASS = "com.crittercism.app.Crittercism";
-		private static AndroidJavaClass mCrittercismsPlugin = null;
+#if CRITTERCISM_ENABLED
+        private static AndroidJavaClass mCrittercismsPlugin = null;
+#endif
 
-		/// <summary>
+        /// <summary>
 		/// Description:
 		/// Start Crittercism for Unity, will start crittercism for android if it is not already active.
 		/// Parameters:
 		/// appID: Crittercisms Provided App ID for this application
 		/// </summary>
 		public static void Init (string appID)
-		{
+        {
 				Init (appID, new CrittercismConfig ());
-		}
+        }
 
-		public static void Init (string appID, CrittercismConfig config)
-		{
-				if (Application.platform != RuntimePlatform.Android) {
-						System.Console.Write ("CrittercismAndroid only supports the Android platform. Crittercism will not be enabled");
-						return;
-				}
+        public static void Init(string appID, CrittercismConfig config)
+        {
+#if CRITTERCISM_ENABLED
+            if (isInitialized)
+            {
+                UnityEngine.Debug.Log("CrittercismAndroid is already initialized.");
+                return;
+            }
 
-				if (isInitialized) {
-						System.Console.Write ("CrittercismAndroid is already initialized.");
-						return;
-				}
+            UnityEngine.Debug.Log("Initializing Crittercism with app id " + appID);
 
-				UnityEngine.Debug.Log ("Initializing Crittercism with app id " + appID);
+            AndroidJavaClass cls_UnityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
+            AndroidJavaObject objActivity = cls_UnityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
 
-				AndroidJavaClass cls_UnityPlayer = new AndroidJavaClass ("com.unity3d.player.UnityPlayer");
-				AndroidJavaObject objActivity = cls_UnityPlayer.GetStatic<AndroidJavaObject> ("currentActivity");
+            mCrittercismsPlugin = new AndroidJavaClass(CRITTERCISM_CLASS);
+            if (mCrittercismsPlugin == null)
+            {
+                UnityEngine.Debug.Log("CrittercismAndroid failed to initialize.  Unable to find class " + CRITTERCISM_CLASS);
+                return;
+            }
 
-				mCrittercismsPlugin = new AndroidJavaClass (CRITTERCISM_CLASS);
-				if (mCrittercismsPlugin == null) {
-						System.Console.Write ("CrittercismAndroid failed to initialize.  Unable to find class " + CRITTERCISM_CLASS);
-						return;
-				}
+            _CallPluginStatic("initialize", objActivity, appID, config.GetAndroidConfig());
 
-				mCrittercismsPlugin.CallStatic ("initialize", objActivity, appID, config.GetAndroidConfig ());
+            System.AppDomain.CurrentDomain.UnhandledException += _OnUnresolvedExceptionHandler;
+            Application.RegisterLogCallback(_OnDebugLogCallbackHandler);
 
-				System.AppDomain.CurrentDomain.UnhandledException += _OnUnresolvedExceptionHandler;
-				Application.RegisterLogCallback (_OnDebugLogCallbackHandler);
-
-				isInitialized = true;
-		}
+            isInitialized = true;
+#else
+            UnityEngine.Debug.Log("CrittercismAndroid only supports the Android platform. Crittercism will not be enabled");
+#endif
+        }
 
 		static private void doLogError (string crittercismMethod, System.Exception e)
 		{
@@ -76,17 +82,9 @@ public static class CrittercismAndroid
 						files [i] = frame.GetFileName ();
 						lineNumbers [i] = frame.GetFileLineNumber ();
 				}
-        
-        
-				mCrittercismsPlugin.CallStatic (
-            crittercismMethod, 
-            e.GetType ().Name, 
-            e.Message, 
-            classes, 
-            methods, 
-            files, 
-            lineNumbers);
 
+                _CallPluginStatic(crittercismMethod,
+                    e.GetType().Name, e.Message, classes, methods, files, lineNumbers);
 		}
 
 		static private void logCrash (System.Exception e)
@@ -112,7 +110,7 @@ public static class CrittercismAndroid
 						return false;
 				}
 
-				return mCrittercismsPlugin.CallStatic<bool> ("getOptOutStatus");
+				return _CallPluginStatic<bool> ("getOptOutStatus");
 		}
 
 
@@ -125,7 +123,7 @@ public static class CrittercismAndroid
 						return;
 				}
 
-				mCrittercismsPlugin.CallStatic<bool> ("setOptOutStatus", s);
+                _CallPluginStatic<bool>("setOptOutStatus", s);
 		}
 
 		/// <summary>
@@ -138,7 +136,7 @@ public static class CrittercismAndroid
 						return;
 				}
 
-				mCrittercismsPlugin.CallStatic ("setUsername", username);
+                _CallPluginStatic("setUsername", username);
 		}
 
 		/// <summary>
@@ -151,7 +149,7 @@ public static class CrittercismAndroid
 				}
 
 				if (keys.Length != values.Length) {
-						System.Console.Write ("Crittercism.SetMetadata given arrays of different lengths");
+						UnityEngine.Debug.Log ("Crittercism.SetMetadata given arrays of different lengths");
 						return;
 				}
 
@@ -161,12 +159,19 @@ public static class CrittercismAndroid
 		}
 
 		static public void SetValue (string key, string value)
-		{
-				AndroidJavaClass jsonObject = new AndroidJavaClass ("org.json.JSONObject");
-				jsonObject.Call ("put", key, value);
+        {
+                if (!isInitialized) {
+                    return;
+                }
+#if CRITTERCISM_ENABLED
+				AndroidJavaObject jsonObject = new AndroidJavaObject("org.json.JSONObject");
+                jsonObject.Call<AndroidJavaObject>("put", key, value);
 
-				mCrittercismsPlugin.CallStatic ("setMetadata", jsonObject);
-		}
+                //TODO: using AndroidJavaClass and AndroidJavaObject can be really expensive in C#
+                //consider add a overload method void setMetadata(string key, string value) in java side
+                _CallPluginStatic("setMetadata", jsonObject);
+#endif
+        }
 
 		/// <summary>
 		/// Leave a breadcrumb for tracking.
@@ -177,7 +182,7 @@ public static class CrittercismAndroid
 						return;
 				}
 
-				mCrittercismsPlugin.CallStatic ("leaveBreadcrumb", l);
+                _CallPluginStatic("leaveBreadcrumb", l);
 		}
 
 		static private void _OnUnresolvedExceptionHandler (object sender, System.UnhandledExceptionEventArgs args)
@@ -201,15 +206,35 @@ public static class CrittercismAndroid
 
 				if (!isInitialized) {
 						return;
-				}
+                }
 
+#if CRITTERCISM_ENABLED
 				try {
 						AndroidJavaClass pluginExceptionClass = new AndroidJavaClass ("com.crittercism.integrations.PluginException");
 						AndroidJavaObject exception = pluginExceptionClass.CallStatic<AndroidJavaObject> ("createUnityException", name, stack);
-
-						mCrittercismsPlugin.CallStatic ("_logCrashException", exception);
-				} catch (System.Exception e) {
-						System.Console.Write ("Unable to log a crash exception to Crittercism to to an unexpected error: " + e.ToString ());
+                        
+                        //TODO: using AndroidJavaClass and AndroidJavaObject can be really expensive in C#
+                        //consider add a overload method void _logCrashException(string name, string stack) in java side
+						_CallPluginStatic ("_logCrashException", exception);
+                } catch (System.Exception e) {
+						UnityEngine.Debug.Log ("Unable to log a crash exception to Crittercism to to an unexpected error: " + e.ToString ());
 				}
-		}
+#endif
+        }
+
+        static private void _CallPluginStatic(string methodName, params object[] args)
+        {
+#if CRITTERCISM_ENABLED
+            mCrittercismsPlugin.CallStatic(methodName, args);
+#endif
+        }
+
+        static private RetType _CallPluginStatic<RetType>(string methodName, params object[] args)
+        {
+#if CRITTERCISM_ENABLED
+            return mCrittercismsPlugin.CallStatic<RetType>(methodName, args);
+#else
+            return default(RetType);
+#endif
+        }
 }

--- a/DemoApp/Assets/Plugins/Crittercism_Android_Scripts/CrittercismConfig.cs
+++ b/DemoApp/Assets/Plugins/Crittercism_Android_Scripts/CrittercismConfig.cs
@@ -1,38 +1,62 @@
+#if UNITY_ANDROID && !UNITY_EDITOR
+#define CRITTERCISM_ENABLED
+#endif
+
 using UnityEngine;
 using System.Collections;
 
-public class CrittercismConfig : MonoBehaviour
+public class CrittercismConfig
 {
 	private static readonly string CRITTERCISM_CONFIG_CLASS = "com.crittercism.app.CrittercismConfig";
+#if CRITTERCISM_ENABLED
 	private AndroidJavaObject mCrittercismConfig = null;
 
-	public CrittercismConfig ()
+	
+    public CrittercismConfig ()
 	{
 		mCrittercismConfig = new AndroidJavaObject(CRITTERCISM_CONFIG_CLASS);
 	}
 
-	public string GetCustomVersionName ()
+    public AndroidJavaObject GetAndroidConfig ()
+    {
+		return mCrittercismConfig;
+	}
+#endif
+
+    public string GetCustomVersionName ()
 	{
-		return mCrittercismConfig.Call<string>("getCustomVersionName");
+        return CallConfigMethod<string>("getCustomVersionName");
 	}
 
 	public void SetCustomVersionName (string customVersionName)
 	{
-		mCrittercismConfig.Call ("setCustomVersionName", customVersionName);
+        CallConfigMethod("setCustomVersionName", customVersionName);
 	}
 
 	public bool IsLogcatReportingEnabled ()
 	{
-		return mCrittercismConfig.Call<bool> ("isLogcatReportingEnabled");
+        return CallConfigMethod<bool>("isLogcatReportingEnabled");
 	}
 
 	public void SetLogcatReportingEnabled (bool shouldCollectLogcat)
 	{
-		mCrittercismConfig.Call ("setLogcatReportingEnabled", shouldCollectLogcat);
-	}
+        CallConfigMethod("setLogcatReportingEnabled", shouldCollectLogcat);
+    }
+    
+    void CallConfigMethod(string methodName, params object[] args)
+    {
+#if CRITTERCISM_ENABLED
+        mCrittercismConfig.Call(methodName, args);
+#endif
+    }
 
-	public AndroidJavaObject GetAndroidConfig () {
-		return mCrittercismConfig;
-	}
+    RetType CallConfigMethod<RetType>(string methodName, params object[] args)
+    {
+#if CRITTERCISM_ENABLED
+        return mCrittercismConfig.Call<RetType>(methodName, args);
+#else
+        return default(RetType);
+#endif
+    }
 }
 

--- a/DemoApp/Assets/Plugins/Crittercism_Android_Scripts/CrittercismConfig.cs
+++ b/DemoApp/Assets/Plugins/Crittercism_Android_Scripts/CrittercismConfig.cs
@@ -7,56 +7,54 @@ using System.Collections;
 
 public class CrittercismConfig
 {
-	private static readonly string CRITTERCISM_CONFIG_CLASS = "com.crittercism.app.CrittercismConfig";
+		private static readonly string CRITTERCISM_CONFIG_CLASS = "com.crittercism.app.CrittercismConfig";
 #if CRITTERCISM_ENABLED
-	private AndroidJavaObject mCrittercismConfig = null;
+		private AndroidJavaObject mCrittercismConfig = null;
 
-	
-    public CrittercismConfig ()
-	{
-		mCrittercismConfig = new AndroidJavaObject(CRITTERCISM_CONFIG_CLASS);
-	}
+		public CrittercismConfig()
+		{
+				mCrittercismConfig = new AndroidJavaObject(CRITTERCISM_CONFIG_CLASS);
+		}
 
-    public AndroidJavaObject GetAndroidConfig ()
-    {
-		return mCrittercismConfig;
-	}
+		public AndroidJavaObject GetAndroidConfig()
+		{
+				return mCrittercismConfig;
+		}
 #endif
 
-    public string GetCustomVersionName ()
-	{
-        return CallConfigMethod<string>("getCustomVersionName");
-	}
+		public string GetCustomVersionName()
+		{
+				return CallConfigMethod<string>("getCustomVersionName");
+		}
 
-	public void SetCustomVersionName (string customVersionName)
-	{
-        CallConfigMethod("setCustomVersionName", customVersionName);
-	}
+		public void SetCustomVersionName(string customVersionName)
+		{
+				CallConfigMethod("setCustomVersionName", customVersionName);
+		}
 
-	public bool IsLogcatReportingEnabled ()
-	{
-        return CallConfigMethod<bool>("isLogcatReportingEnabled");
-	}
+		public bool IsLogcatReportingEnabled()
+		{
+				return CallConfigMethod<bool>("isLogcatReportingEnabled");
+		}
 
-	public void SetLogcatReportingEnabled (bool shouldCollectLogcat)
-	{
-        CallConfigMethod("setLogcatReportingEnabled", shouldCollectLogcat);
-    }
-    
-    void CallConfigMethod(string methodName, params object[] args)
-    {
+		public void SetLogcatReportingEnabled(bool shouldCollectLogcat)
+		{
+				CallConfigMethod("setLogcatReportingEnabled", shouldCollectLogcat);
+		}
+
+		void CallConfigMethod(string methodName, params object[] args)
+		{
 #if CRITTERCISM_ENABLED
-        mCrittercismConfig.Call(methodName, args);
+				mCrittercismConfig.Call(methodName, args);
 #endif
-    }
+		}
 
-    RetType CallConfigMethod<RetType>(string methodName, params object[] args)
-    {
+		RetType CallConfigMethod<RetType>(string methodName, params object[] args)
+		{
 #if CRITTERCISM_ENABLED
-        return mCrittercismConfig.Call<RetType>(methodName, args);
+				return mCrittercismConfig.Call<RetType>(methodName, args);
 #else
-        return default(RetType);
+				return default(RetType);
 #endif
-    }
+		}
 }
-

--- a/DemoApp/Assets/Plugins/Crittercism_Android_Scripts/CrittercismTestGUI.cs
+++ b/DemoApp/Assets/Plugins/Crittercism_Android_Scripts/CrittercismTestGUI.cs
@@ -10,21 +10,23 @@ public class CrittercismTestGUI : MonoBehaviour
 
         int screenButtonHeight = Screen.height / 8;
 
-        if (GUI.Button (new Rect (0, 0, Screen.width, screenButtonHeight), "Leave breadcrumb", customStyle)) {
+        if (GUI.Button (new Rect (0, 0, Screen.width, screenButtonHeight), "Leave Breadcrumb", customStyle)) {
             CrittercismAndroid.LeaveBreadcrumb ("BreadCrumb");
         }
 
-        if (GUI.Button (new Rect (0, screenButtonHeight, Screen.width, screenButtonHeight), "Set User Metadata", customStyle)) {
-            CrittercismAndroid.SetUsername ("MommaCritter");
-            CrittercismAndroid.SetValue ("5", "Game Level");
-            CrittercismAndroid.SetValue ("Crashes a lot", "Status");
+        if (GUI.Button (new Rect (0, screenButtonHeight, Screen.width, screenButtonHeight), "Set Username", customStyle)) {
+            CrittercismAndroid.SetUsername("MommaCritter");
         }
 
-        if (GUI.Button (new Rect (0, screenButtonHeight * 2, Screen.width, screenButtonHeight), "C# Crash", customStyle)) {
+        if (GUI.Button(new Rect(0, screenButtonHeight * 2, Screen.width, screenButtonHeight), "Set Metadata", customStyle)) {
+            CrittercismAndroid.SetMetadata(new string[] { "Game Level", "Status" }, new string[] { "5", "Crashes a lot" });
+        }
+
+        if (GUI.Button (new Rect (0, screenButtonHeight * 3, Screen.width, screenButtonHeight), "C# Crash", customStyle)) {
             causeDivideByZeroException ();
         }
 
-        if (GUI.Button (new Rect (0, screenButtonHeight * 3, Screen.width, screenButtonHeight), "C# Handled Exception", customStyle)) {
+        if (GUI.Button (new Rect (0, screenButtonHeight * 4, Screen.width, screenButtonHeight), "C# Handled Exception", customStyle)) {
             try {
                 causeDivideByZeroException ();
             } catch (System.Exception e) {
@@ -32,7 +34,7 @@ public class CrittercismTestGUI : MonoBehaviour
             }
         }
 
-        if (GUI.Button (new Rect (0, screenButtonHeight * 4, Screen.width, screenButtonHeight), "C# Null Pointer Exception", customStyle)) {
+        if (GUI.Button (new Rect (0, screenButtonHeight * 5, Screen.width, screenButtonHeight), "C# Null Pointer Exception", customStyle)) {
             causeNullPointerException ();
         }
     }

--- a/Plugins/Crittercism_Android_Scripts/CrittercismConfig.cs
+++ b/Plugins/Crittercism_Android_Scripts/CrittercismConfig.cs
@@ -1,38 +1,60 @@
+#if UNITY_ANDROID && !UNITY_EDITOR
+#define CRITTERCISM_ENABLED
+#endif
+
 using UnityEngine;
 using System.Collections;
 
-public class CrittercismConfig : MonoBehaviour
+public class CrittercismConfig
 {
-	private static readonly string CRITTERCISM_CONFIG_CLASS = "com.crittercism.app.CrittercismConfig";
-	private AndroidJavaObject mCrittercismConfig = null;
+		private static readonly string CRITTERCISM_CONFIG_CLASS = "com.crittercism.app.CrittercismConfig";
+#if CRITTERCISM_ENABLED
+		private AndroidJavaObject mCrittercismConfig = null;
 
-	public CrittercismConfig ()
-	{
-		mCrittercismConfig = new AndroidJavaObject(CRITTERCISM_CONFIG_CLASS);
-	}
+		public CrittercismConfig()
+		{
+				mCrittercismConfig = new AndroidJavaObject(CRITTERCISM_CONFIG_CLASS);
+		}
 
-	public string GetCustomVersionName ()
-	{
-		return mCrittercismConfig.Call<string>("getCustomVersionName");
-	}
+		public AndroidJavaObject GetAndroidConfig()
+		{
+				return mCrittercismConfig;
+		}
+#endif
 
-	public void SetCustomVersionName (string customVersionName)
-	{
-		mCrittercismConfig.Call ("setCustomVersionName", customVersionName);
-	}
+		public string GetCustomVersionName()
+		{
+				return CallConfigMethod<string>("getCustomVersionName");
+		}
 
-	public bool IsLogcatReportingEnabled ()
-	{
-		return mCrittercismConfig.Call<bool> ("isLogcatReportingEnabled");
-	}
+		public void SetCustomVersionName(string customVersionName)
+		{
+				CallConfigMethod("setCustomVersionName", customVersionName);
+		}
 
-	public void SetLogcatReportingEnabled (bool shouldCollectLogcat)
-	{
-		mCrittercismConfig.Call ("setLogcatReportingEnabled", shouldCollectLogcat);
-	}
+		public bool IsLogcatReportingEnabled()
+		{
+				return CallConfigMethod<bool>("isLogcatReportingEnabled");
+		}
 
-	public AndroidJavaObject GetAndroidConfig () {
-		return mCrittercismConfig;
-	}
+		public void SetLogcatReportingEnabled(bool shouldCollectLogcat)
+		{
+				CallConfigMethod("setLogcatReportingEnabled", shouldCollectLogcat);
+		}
+
+		void CallConfigMethod(string methodName, params object[] args)
+		{
+#if CRITTERCISM_ENABLED
+				mCrittercismConfig.Call(methodName, args);
+#endif
+		}
+
+		RetType CallConfigMethod<RetType>(string methodName, params object[] args)
+		{
+#if CRITTERCISM_ENABLED
+				return mCrittercismConfig.Call<RetType>(methodName, args);
+#else
+				return default(RetType);
+#endif
+		}
 }
-


### PR DESCRIPTION
fix SetValue method in CrittercismAndroid, use AndroidJavaObject to create JSONObject instance, not AndroidJavaClass
CrittercismConfig should not be a sub class of MonoBehaviour , create instance of MonoBehaviour is invalid using keyword 'new'
add a SetMeta button in TestGUI script
recommend:
using AndroidJavaObject and AndroidJavaClass are really expensive in C#, consider add some overload methods in java sdk to create java Object instances in java side, see Comments in SetValue method in CrittercismAndroid